### PR TITLE
Preserve line breaks if not in reader mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: subosito/flutter-action@v1
       with:
-        channel: 'beta'
+        channel: 'stable'
     - name: Install dependencies
       run: flutter pub get
     - name: Analyze

--- a/lib/src/span.dart
+++ b/lib/src/span.dart
@@ -121,7 +121,7 @@ class OrgSpanBuilder {
             .map((child) => build(
                   child,
                   style: style,
-                  transformer: transformer == identityTransformer
+                  transformer: transformer == identityTransformer && hideMarkup
                       ? (elem, text) => reflowText(
                             text,
                             end: element.content.children.last == elem,

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -756,6 +756,7 @@ class OrgParagraphWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final hideMarkup = OrgController.of(context).hideMarkup;
     return IndentBuilder(
       paragraph.indent,
       builder: (context, totalIndentSize) {
@@ -763,11 +764,13 @@ class OrgParagraphWidget extends StatelessWidget {
           paragraph.body,
           transformer: (elem, content) {
             final isLast = elem == paragraph.body.children.last;
-            final reflowed = reflowText(
-              deindent(content, totalIndentSize),
-              end: isLast,
-            );
-            return isLast ? removeTrailingLineBreak(reflowed) : reflowed;
+            var formattedContent = deindent(content, totalIndentSize);
+            if (hideMarkup) {
+              formattedContent = reflowText(formattedContent, end: isLast);
+            }
+            return isLast
+                ? removeTrailingLineBreak(formattedContent)
+                : formattedContent;
           },
         );
       },


### PR DESCRIPTION
Hey @amake. This here is a trivial implementation of amake/orgro#73. Simply skip the text reflowing if not in reader mode.

Would you be happy with this solution? Or would you rather have a separate toggleable option next to reader mode?

Personally, I think this solution fits well and is an appropriate interpretation of reader mode.